### PR TITLE
fix: use ARG in CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,5 @@ ARG GO_APP_NAME=watcher
 COPY --from=builder /app/$GO_APP_NAME /app/$GO_APP_NAME
 WORKDIR /app
 
-CMD ./$GO_APP_NAME
+ENV GO_APP_NAME=${GO_APP_NAME}
+CMD ./${GO_APP_NAME}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ docker buildx bake
 ### Run watcher
 
 ```shell
-docker run -v /var/run/docker.sock:/var/run/docker.sock -p 9001:9001 tinygoexercise:local-dev-api ./watcher
+docker run \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -p 9001:9001 \
+  tinygoexercise:local-dev-api
 ```
 
 Note: In order to gain access to the Docker Engine API, we must gain access to the socket connect via mount `/var/run/docker.sock`.
@@ -26,5 +29,8 @@ Note: In order to gain access to the Docker Engine API, we must gain access to t
 ### Run controller
 
 ```shell
-docker run -v /var/run/docker.sock:/var/run/docker.sock --net=host tinygoexercise:local-dev-controller ./controller
+docker run \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  --net=host \
+  tinygoexercise:local-dev-controller
 ```


### PR DESCRIPTION
Pass `ARG` to `ENV` in order to use it in `CMD`.